### PR TITLE
Added elevation column to Building and utilize it as buildingZ when tesselating

### DIFF
--- a/src/tesselate_building/tesselate_building_core/Building.cs
+++ b/src/tesselate_building/tesselate_building_core/Building.cs
@@ -7,10 +7,11 @@ namespace tesselate_building_core
     {
         public Geometry Geometry { get; set; }
         public double Height { get; set; }
+        public double Elevation { get; set; }
 
         public int Id { get; set; }
 
-        public string Style { get; set; } 
+        public string Style { get; set; }
 
         public BuildingStyle BuildingStyle
         {

--- a/src/tesselate_building/tesselate_building_core/TesselateBuilding.cs
+++ b/src/tesselate_building/tesselate_building_core/TesselateBuilding.cs
@@ -19,7 +19,7 @@ namespace tesselate_building_core
             polyhedral.Geometries.Add(GetPolygonZ(footprint, fromZ + height));
             if (buildingStyle.Storeys == null)
             {
-                var walls = MakeWalls(footprint, fromZ, height - fromZ);
+                var walls = MakeWalls(footprint, fromZ, height);
                 polyhedral.Geometries.AddRange(walls);
             }
             else
@@ -27,7 +27,7 @@ namespace tesselate_building_core
                 {
                     foreach (var storey in buildingStyle.Storeys)
                     {
-                        var walls = MakeWalls(footprint, fromZ + storey.From, storey.To - storey.From);
+                        var walls = MakeWalls(footprint, fromZ, storey.To - storey.From);
                         polyhedral.Geometries.AddRange(walls);
                     }
                 }

--- a/src/tesselate_building/tesselate_building_sample_console/Options.cs
+++ b/src/tesselate_building/tesselate_building_sample_console/Options.cs
@@ -31,6 +31,9 @@ namespace tesselate_building_sample_console
         [Option("heightcolumn", Required = false, Default = "height", HelpText = "height column")]
         public string HeightColumn { get; set; }
 
+        [Option("elevationcolumn", Required = false, Default = "elevation", HelpText = "elevation column")]
+        public string ElevationColumn { get; set; }
+
         [Option("idcolumn", Required = false, Default = "id", HelpText = "Id column")]
         public string IdColumn { get; set; }
 

--- a/src/tesselate_building/tesselate_building_sample_console/Program.cs
+++ b/src/tesselate_building/tesselate_building_sample_console/Program.cs
@@ -46,7 +46,7 @@ namespace tesselate_building_sample_console
                 // write tablename to console
                 Console.WriteLine($"Table: {o.Table}");
 
-                var select = $"select ST_AsBinary({o.InputGeometryColumn}) as geometry, {o.HeightColumn} as height, style, {o.IdColumn} as id";
+                var select = $"select ST_AsBinary({o.InputGeometryColumn}) as geometry, {o.HeightColumn} as height, {o.ElevationColumn} as elevation, style, {o.IdColumn} as id";
                 var sql = $"{select} from {o.Table}";
 
                 var buildings = conn.Query<Building>(sql);
@@ -59,7 +59,7 @@ namespace tesselate_building_sample_console
                     var height = building.Height;
                     var points = polygon.ExteriorRing.Points;
 
-                    var buildingZ = 0; //put everything on the ground
+                    var buildingZ = building.Elevation;
                     var res = TesselateBuilding.MakeBuilding(polygon, buildingZ, height, building.BuildingStyle);
                     var wkt = res.polyhedral.SerializeString<WktSerializer>();
 


### PR DESCRIPTION
A simple change to add a new column called "elevation" to the database.  This will require update https://github.com/bertt/pg2b3dm/blob/master/getting_started.md to add the new column.  If nothing is done, it will simply be zero but this will allow users to obtain elevation from another source and tesselate it correctly to render in CesiumJS along with the terrain tiles.

Also found bug in call to MakeWalls.  It only works when buildingZ is zero and hence probably why it was missed.